### PR TITLE
Adds Default Enter Key Behavior For Sign-up, Sign-in, and StoreNewPass

### DIFF
--- a/ApplicationLayer/SignInForm.Designer.cs
+++ b/ApplicationLayer/SignInForm.Designer.cs
@@ -142,6 +142,7 @@ namespace ApplicationLayer
             // SignInForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
+            this.AcceptButton = this.signInBtn;
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackColor = System.Drawing.Color.DimGray;
             this.ClientSize = new System.Drawing.Size(522, 353);

--- a/ApplicationLayer/SignUpForm.Designer.cs
+++ b/ApplicationLayer/SignUpForm.Designer.cs
@@ -176,6 +176,7 @@ namespace ApplicationLayer
             // SignUpForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
+            this.AcceptButton = this.signUpBtn;
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackColor = System.Drawing.Color.DimGray;
             this.ClientSize = new System.Drawing.Size(689, 480);

--- a/ApplicationLayer/StoreNewPassForm.Designer.cs
+++ b/ApplicationLayer/StoreNewPassForm.Designer.cs
@@ -145,6 +145,7 @@ namespace ApplicationLayer
             // StoreNewPassForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
+            this.AcceptButton = this.savePassBtn;
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackColor = System.Drawing.Color.DimGray;
             this.ClientSize = new System.Drawing.Size(685, 339);


### PR DESCRIPTION
These commits each add AcceptKey properties to each of these three forms.

The AcceptKey property defines the default behavior when a user clicks the enter key. This feature is commonly found in desktop applications to speed up input.